### PR TITLE
Remove ubuntu 10 & 12 workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10, 12, 14, 16]
+        node-version: [14, 16]
         include:
           - os: macos-latest
             node-version: 14 # LTS


### PR DESCRIPTION
Ubuntu 10 & 12 End of Life ending long ago, no need to check any more